### PR TITLE
Add architecture decision records

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -15,6 +15,12 @@
    It is measured in megabytes, for example 6GB would be 6144M (which it is set to by default), and 10GB would be 10240M.
    You can calculate this by doing: Megabytes of RAM = 1024 * (how many gigabytes you want to allocate to gradle).
 
-# Important Note:
+## Improve build speed
 **Add <org.gradle.parallel=true> and <org.gradle.usecache=true> just underneath the <org.gradle.jvmargs=-Xmx6144M> line for greatly reduced build times.** This is because Architectury uses multiple project modules, but when building the whole project, gradle supports running these builds (along with many other operations) in parallel, using all your CPU cores. The reason why it isn't already added beforehand (anymore), is because importing the gradle project completely fails when this is enabled. After you initially import the project, you can add those lines to speedup gradle.
 PS: If anyone knows how to fix my build system please tell me
+
+# Architecture Decision Records (ADRs)
+
+We document significant architectural decisions in `/docs/adr`.
+If you are proposing a complex change or a major refactor, please include an ADR in your Pull Request.
+See [ADR-000](adr/000-add-architecture-decision-records.md) for context.

--- a/docs/adr/000-add-architecture-decision-records.md
+++ b/docs/adr/000-add-architecture-decision-records.md
@@ -1,0 +1,27 @@
+# 000: Add architecture decision records
+
+**Status:** Accepted\
+**Date:** 23-12-2025
+
+## Context
+TPA++ has become a mess of undocumented and bizarre decisions. It's impossible to reason about the "why" behind certain decisions, especially in the build script.
+
+## Decision
+Add architecture decision records for all future decisions. They will be managed manually.
+
+## Options Considered
+**Do nothing:** We could keep relying on code comments and memory. But that's led to the current mess we have now.\
+**External wiki:** It tends to rot, and if the in-code documentation/comments sucks, an external wiki will surely get outdated.\
+**Automated ADR's / ADR Utility:** No reason to for a small project. Adds unnecessary friction and setup cost
+
+## Consequences
+**Positive:**
+* Source of truth for the "why" behind decisions.
+* Easy to get started, just Markdown documents.
+
+**Negative:**
+* No automation means it's vulnerable to human error. Also means it becomes hard to manage ADR numbers with multiple contributors.
+* Pretty formal for a Minecraft mod... Mitigations:
+  * We will keep ADR's short, casual, and allow bullet points.
+  * Formatting can be loose. Just as long as you can read it without too much effort.
+  * As long as there is a log of reasoning "in the moment" during decisions, it's FINE.

--- a/docs/adr/adr-format.md
+++ b/docs/adr/adr-format.md
@@ -1,0 +1,23 @@
+# [Number]: [Short imperative statement]
+
+**Status:** [Proposed|Accepted|Rejected|Deprecated|Superseded]\
+**Date:** [DD-MM-YYYY]
+
+## Context
+[Narrative description of the problem at the time of commit]
+
+## Decision
+[The specific action we are taking]
+
+## Options Considered
+**[Option A]**: [Why we didn't pick it]
+**[Option B]**: [Why we didn't pick it]
+
+## Consequences
+**Positive:** 
+* [Benefit 1]
+* [Benefit 2]
+
+**Negative:** 
+* [Trade-off 1]
+* [Trade-off 2]


### PR DESCRIPTION
TPA++ has become a mess of bizarre decisions. This adds ADR's so that those decisions are transparent now. More reasoning in docs/adr/000-add-architecture-decision-records.md