### PR TITLE
Refactor AsyncWindup.kt to use object singleton instead of static access

### DIFF
--- a/common/src/main/java/net/superricky/tpaplusplus/commands/accept/AcceptTPA.java
+++ b/common/src/main/java/net/superricky/tpaplusplus/commands/accept/AcceptTPA.java
@@ -11,7 +11,7 @@ import net.superricky.tpaplusplus.util.MsgFmt;
 import net.superricky.tpaplusplus.windupcooldown.cooldown.CommandType;
 import net.superricky.tpaplusplus.windupcooldown.cooldown.AsyncCooldownHelper;
 import net.superricky.tpaplusplus.windupcooldown.cooldown.AsyncCooldownKt;
-import net.superricky.tpaplusplus.windupcooldown.windup.AsyncWindupKt;
+import net.superricky.tpaplusplus.windupcooldown.windup.AsyncWindup;
 import net.superricky.tpaplusplus.windupcooldown.windup.impl.AcceptWindup;
 
 import java.util.Map;
@@ -34,7 +34,7 @@ public class AcceptTPA {
         if (Config.ACCEPT_WINDUP.get() == 0) {
             absoluteAcceptFunctionality(request, receiver);
         } else {
-            AsyncWindupKt.schedule(new AcceptWindup(request));
+            AsyncWindup.INSTANCE.schedule(new AcceptWindup(request));
         }
     }
 

--- a/common/src/main/java/net/superricky/tpaplusplus/commands/back/Back.java
+++ b/common/src/main/java/net/superricky/tpaplusplus/commands/back/Back.java
@@ -7,7 +7,7 @@ import net.superricky.tpaplusplus.config.Messages;
 import net.superricky.tpaplusplus.windupcooldown.cooldown.AsyncCooldownHelper;
 import net.superricky.tpaplusplus.windupcooldown.cooldown.AsyncCooldownKt;
 import net.superricky.tpaplusplus.windupcooldown.cooldown.CommandType;
-import net.superricky.tpaplusplus.windupcooldown.windup.AsyncWindupKt;
+import net.superricky.tpaplusplus.windupcooldown.windup.AsyncWindup;
 import net.superricky.tpaplusplus.windupcooldown.windup.impl.BackWindup;
 import org.jetbrains.annotations.Nullable;
 
@@ -41,7 +41,7 @@ public class Back {
         if (Config.BACK_WINDUP.get() == 0) {
             absoluteTeleportToLatestDeath(executor, deathPosition);
         } else {
-            AsyncWindupKt.schedule(new BackWindup(executor, deathPosition));
+            AsyncWindup.INSTANCE.schedule(new BackWindup(executor, deathPosition));
         }
     }
 

--- a/common/src/main/java/net/superricky/tpaplusplus/commands/block/BlockPlayer.java
+++ b/common/src/main/java/net/superricky/tpaplusplus/commands/block/BlockPlayer.java
@@ -11,7 +11,7 @@ import net.superricky.tpaplusplus.util.MsgFmt;
 import net.superricky.tpaplusplus.windupcooldown.cooldown.AsyncCooldownHelper;
 import net.superricky.tpaplusplus.windupcooldown.cooldown.AsyncCooldownKt;
 import net.superricky.tpaplusplus.windupcooldown.cooldown.CommandType;
-import net.superricky.tpaplusplus.windupcooldown.windup.AsyncWindupKt;
+import net.superricky.tpaplusplus.windupcooldown.windup.AsyncWindup;
 import net.superricky.tpaplusplus.windupcooldown.windup.impl.BlockPlayerWindup;
 
 import java.util.Map;
@@ -42,7 +42,7 @@ public class BlockPlayer {
         if (Config.BLOCK_WINDUP.get() == 0) {
             absoluteBlockPlayer(executorData, executor, blockedPlayer);
         } else {
-            AsyncWindupKt.schedule(new BlockPlayerWindup(executorData, executor, blockedPlayer));
+            AsyncWindup.INSTANCE.schedule(new BlockPlayerWindup(executorData, executor, blockedPlayer));
         }
     }
 

--- a/common/src/main/java/net/superricky/tpaplusplus/commands/cancel/CancelTPA.java
+++ b/common/src/main/java/net/superricky/tpaplusplus/commands/cancel/CancelTPA.java
@@ -11,7 +11,7 @@ import net.superricky.tpaplusplus.util.MsgFmt;
 import net.superricky.tpaplusplus.windupcooldown.cooldown.AsyncCooldownHelper;
 import net.superricky.tpaplusplus.windupcooldown.cooldown.AsyncCooldownKt;
 import net.superricky.tpaplusplus.windupcooldown.cooldown.CommandType;
-import net.superricky.tpaplusplus.windupcooldown.windup.AsyncWindupKt;
+import net.superricky.tpaplusplus.windupcooldown.windup.AsyncWindup;
 import net.superricky.tpaplusplus.windupcooldown.windup.impl.CancelWindup;
 
 import java.util.Map;
@@ -34,7 +34,7 @@ public class CancelTPA {
         if (Config.CANCEL_WINDUP.get() == 0) {
             absoluteCancel(request);
         } else {
-            AsyncWindupKt.schedule(new CancelWindup(request));
+            AsyncWindup.INSTANCE.schedule(new CancelWindup(request));
         }
     }
 

--- a/common/src/main/java/net/superricky/tpaplusplus/commands/deny/DenyTPA.java
+++ b/common/src/main/java/net/superricky/tpaplusplus/commands/deny/DenyTPA.java
@@ -11,7 +11,7 @@ import net.superricky.tpaplusplus.util.MsgFmt;
 import net.superricky.tpaplusplus.windupcooldown.cooldown.AsyncCooldownHelper;
 import net.superricky.tpaplusplus.windupcooldown.cooldown.AsyncCooldownKt;
 import net.superricky.tpaplusplus.windupcooldown.cooldown.CommandType;
-import net.superricky.tpaplusplus.windupcooldown.windup.AsyncWindupKt;
+import net.superricky.tpaplusplus.windupcooldown.windup.AsyncWindup;
 import net.superricky.tpaplusplus.windupcooldown.windup.impl.DenyWindup;
 
 import java.util.Map;
@@ -34,7 +34,7 @@ public class DenyTPA {
         if (Config.DENY_WINDUP.get() == 0) {
             absoluteDeny(request);
         } else {
-            AsyncWindupKt.schedule(new DenyWindup(request));
+            AsyncWindup.INSTANCE.schedule(new DenyWindup(request));
         }
     }
 

--- a/common/src/main/java/net/superricky/tpaplusplus/commands/send/SendTPA.java
+++ b/common/src/main/java/net/superricky/tpaplusplus/commands/send/SendTPA.java
@@ -15,7 +15,7 @@ import net.superricky.tpaplusplus.util.MsgFmt;
 import net.superricky.tpaplusplus.windupcooldown.cooldown.AsyncCooldownHelper;
 import net.superricky.tpaplusplus.windupcooldown.cooldown.AsyncCooldownKt;
 import net.superricky.tpaplusplus.windupcooldown.cooldown.CommandType;
-import net.superricky.tpaplusplus.windupcooldown.windup.AsyncWindupKt;
+import net.superricky.tpaplusplus.windupcooldown.windup.AsyncWindup;
 import net.superricky.tpaplusplus.windupcooldown.windup.impl.TPAHereWindup;
 import net.superricky.tpaplusplus.windupcooldown.windup.impl.TPAWindup;
 
@@ -72,7 +72,7 @@ public class SendTPA {
             if (Config.TPAHERE_WINDUP.get() == 0) {
                 absoluteSendTeleportRequest(sender, receiver, isHereRequest);
             } else {
-                AsyncWindupKt.schedule(new TPAHereWindup(sender, receiver));
+                AsyncWindup.INSTANCE.schedule(new TPAHereWindup(sender, receiver));
             }
         } else {
             if (AsyncCooldownHelper.checkCommandCooldownAndNotify(sender, sender.getUUID(), CommandType.TPA))
@@ -84,7 +84,7 @@ public class SendTPA {
             if (Config.TPA_WINDUP.get() == 0) {
                 absoluteSendTeleportRequest(sender, receiver, isHereRequest);
             } else {
-                AsyncWindupKt.schedule(new TPAWindup(sender, receiver));
+                AsyncWindup.INSTANCE.schedule(new TPAWindup(sender, receiver));
             }
         }
     }

--- a/common/src/main/java/net/superricky/tpaplusplus/commands/toggle/TPToggle.java
+++ b/common/src/main/java/net/superricky/tpaplusplus/commands/toggle/TPToggle.java
@@ -10,7 +10,7 @@ import net.superricky.tpaplusplus.io.SaveDataManager;
 import net.superricky.tpaplusplus.windupcooldown.cooldown.AsyncCooldownHelper;
 import net.superricky.tpaplusplus.windupcooldown.cooldown.AsyncCooldownKt;
 import net.superricky.tpaplusplus.windupcooldown.cooldown.CommandType;
-import net.superricky.tpaplusplus.windupcooldown.windup.AsyncWindupKt;
+import net.superricky.tpaplusplus.windupcooldown.windup.AsyncWindup;
 import net.superricky.tpaplusplus.windupcooldown.windup.impl.TPToggleWindup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,7 +35,7 @@ public class TPToggle {
         if (Config.TOGGLE_WINDUP.get() == 0) {
             toggleTP(executor);
         } else {
-            AsyncWindupKt.schedule(new TPToggleWindup(executor));
+            AsyncWindup.INSTANCE.schedule(new TPToggleWindup(executor));
         }
     }
 

--- a/common/src/main/java/net/superricky/tpaplusplus/commands/unblock/UnBlockPlayer.java
+++ b/common/src/main/java/net/superricky/tpaplusplus/commands/unblock/UnBlockPlayer.java
@@ -12,7 +12,7 @@ import net.superricky.tpaplusplus.util.MsgFmt;
 import net.superricky.tpaplusplus.windupcooldown.cooldown.AsyncCooldownHelper;
 import net.superricky.tpaplusplus.windupcooldown.cooldown.AsyncCooldownKt;
 import net.superricky.tpaplusplus.windupcooldown.cooldown.CommandType;
-import net.superricky.tpaplusplus.windupcooldown.windup.AsyncWindupKt;
+import net.superricky.tpaplusplus.windupcooldown.windup.AsyncWindup;
 import net.superricky.tpaplusplus.windupcooldown.windup.impl.UnBlockPlayerWindup;
 
 import java.util.Map;
@@ -43,7 +43,7 @@ public class UnBlockPlayer {
         if (Config.UNBLOCK_WINDUP.get() == 0) {
             absoluteUnBlockPlayer(executorData, executor, blockedPlayer);
         } else {
-            AsyncWindupKt.schedule(new UnBlockPlayerWindup(executorData, executor, blockedPlayer));
+            AsyncWindup.INSTANCE.schedule(new UnBlockPlayerWindup(executorData, executor, blockedPlayer));
         }
     }
 

--- a/common/src/main/java/net/superricky/tpaplusplus/windupcooldown/windup/AsyncWindup.kt
+++ b/common/src/main/java/net/superricky/tpaplusplus/windupcooldown/windup/AsyncWindup.kt
@@ -5,57 +5,59 @@ import net.minecraft.network.chat.Component
 import net.superricky.tpaplusplus.config.Messages
 import net.superricky.tpaplusplus.util.MsgFmt
 
-private val dispatcher: CoroutineDispatcher = Dispatchers.IO
-private val scope: CoroutineScope = CoroutineScope(dispatcher)
+object AsyncWindup {
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+    private val scope: CoroutineScope = CoroutineScope(dispatcher)
 
-fun schedule(abstractWindup: AbstractWindup) {
-    require(!abstractWindup.cancelled.get()) { "Tried to schedule a windupData that has already been cancelled." }
+    fun schedule(abstractWindup: AbstractWindup) {
+        require(!abstractWindup.cancelled.get()) { "Tried to schedule a windupData that has already been cancelled." }
 
-    // Request is a valid request.
-    addWindupData(abstractWindup) // Add it to the tracked windupData.
+        // Request is a valid request.
+        addWindupData(abstractWindup) // Add it to the tracked windupData.
 
-    scope.launch {
-        var countingDown = true
-        while (countingDown) {
-            countingDown = countdownIteratively(abstractWindup)
-            delay(1000L)
+        scope.launch {
+            var countingDown = true
+            while (countingDown) {
+                countingDown = countdownIteratively(abstractWindup)
+                delay(1000L)
+            }
         }
     }
-}
 
-/**
- * @return True if the countdown should be continued for another iteration
- *         False if the countdown should stop
- */
-private fun countdownIteratively(abstractWindup: AbstractWindup): Boolean {
-    if (abstractWindup.windupDelay.get() > 0) {
-        // Countdown not finished
+    /**
+     * @return True if the countdown should be continued for another iteration
+     *         False if the countdown should stop
+     */
+    private fun countdownIteratively(abstractWindup: AbstractWindup): Boolean {
+        if (abstractWindup.windupDelay.get() > 0) {
+            // Countdown not finished
+            if (abstractWindup.cancelled.get()) {
+                removeWindupData(abstractWindup)
+                return false
+            }
+
+            abstractWindup.windupPlayer.sendSystemMessage(Component.literal(MsgFmt.fmt(Messages.WINDUP_TIME_REMAINING.get(),
+                mapOf("time" to abstractWindup.windupDelay.toString()))))
+
+            abstractWindup.windupDelay.decrementAndGet()
+            return true
+        }
+
         if (abstractWindup.cancelled.get()) {
             removeWindupData(abstractWindup)
             return false
         }
 
-        abstractWindup.windupPlayer.sendSystemMessage(Component.literal(MsgFmt.fmt(Messages.WINDUP_TIME_REMAINING.get(),
-            mapOf("time" to abstractWindup.windupDelay.toString()))))
+        // Delay is zero, countdown finished
+        onCountdownFinished(abstractWindup)
 
-        abstractWindup.windupDelay.decrementAndGet()
-        return true
-    }
-
-    if (abstractWindup.cancelled.get()) {
         removeWindupData(abstractWindup)
         return false
     }
 
-    // Delay is zero, countdown finished
-    onCountdownFinished(abstractWindup)
-
-    removeWindupData(abstractWindup)
-    return false
-}
 
 
-
-private fun onCountdownFinished(abstractWindup: AbstractWindup) {
-    abstractWindup.onWindupFinished()
+    private fun onCountdownFinished(abstractWindup: AbstractWindup) {
+        abstractWindup.onWindupFinished()
+    }
 }


### PR DESCRIPTION
Refactor AsyncWindup.kt to use object singleton instead of static access. Prevents namespace pollution from top-level functions. The JIT optimises singletons to static access anyway.