### PR TITLE
Refactor WindupWatcher.kt to use object {} singleton instead of stati…

### DIFF
--- a/common/src/main/java/net/superricky/tpaplusplus/TPAPlusPlus.java
+++ b/common/src/main/java/net/superricky/tpaplusplus/TPAPlusPlus.java
@@ -20,7 +20,7 @@ import net.superricky.tpaplusplus.network.UpdateCheckKt;
 import net.superricky.tpaplusplus.timeout.RequestTimeoutEvent;
 import net.superricky.tpaplusplus.timeout.TimeoutManagerKt;
 import net.superricky.tpaplusplus.util.MsgFmt;
-import net.superricky.tpaplusplus.windupcooldown.windup.WindupWatcherKt;
+import net.superricky.tpaplusplus.windupcooldown.windup.WindupWatcher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,11 +67,11 @@ public class TPAPlusPlus {
         if (Config.USE_NON_BLOCKING_ASYNC_TICK_LOOP.get()) {
             LOGGER.warn("USING EXPERIMENTAL NON BLOCKING TICK LOOP");
             LOGGER.info(MsgFmt.fmt("INITIALIZING TICK LOOP WITH RATE OF ${tick_rate}...", Map.of("tick_rate", Config.ASYNC_TICK_LOOP_UPDATE_RATE.get())));
-            WindupWatcherKt.startAsyncTickLoop(Config.ASYNC_TICK_LOOP_UPDATE_RATE.get());
+            WindupWatcher.INSTANCE.startAsyncTickLoop(Config.ASYNC_TICK_LOOP_UPDATE_RATE.get());
         } else {
             LOGGER.info("USING SYNCHRONOUS TICK LOOP");
             LOGGER.info("REGISTERING \"TickEvent.SERVER_POST\"...");
-            TickEvent.SERVER_POST.register(server -> WindupWatcherKt.runTick());
+            TickEvent.SERVER_POST.register(server -> WindupWatcher.INSTANCE.runTick());
         }
 
         LOGGER.info("INITIALIZING VERSION CHECKING...");

--- a/common/src/main/java/net/superricky/tpaplusplus/commands/tpaplusplus/TPAPlusPlusCommand.java
+++ b/common/src/main/java/net/superricky/tpaplusplus/commands/tpaplusplus/TPAPlusPlusCommand.java
@@ -14,7 +14,7 @@ import net.superricky.tpaplusplus.config.Messages;
 import net.superricky.tpaplusplus.network.UpdateCheckKt;
 import net.superricky.tpaplusplus.requests.RequestHelper;
 import net.superricky.tpaplusplus.util.MsgFmt;
-import net.superricky.tpaplusplus.windupcooldown.windup.WindupWatcherKt;
+import net.superricky.tpaplusplus.windupcooldown.windup.WindupWatcher;
 
 import java.util.Map;
 import java.util.Objects;
@@ -143,7 +143,7 @@ public class TPAPlusPlusCommand {
 
             RequestHelper.clearRequestSet();
             DeathHelper.clearDeathCoordinates();
-            WindupWatcherKt.clearTrackedWindupData();
+            WindupWatcher.INSTANCE.clearTrackedWindupData();
 
             source.sendSystemMessage(Component.literal(Messages.TPAPLUSPLUS_FORCE_RELOADED_CONFIG.get()));
             return 1;

--- a/common/src/main/java/net/superricky/tpaplusplus/windupcooldown/windup/AsyncWindup.kt
+++ b/common/src/main/java/net/superricky/tpaplusplus/windupcooldown/windup/AsyncWindup.kt
@@ -13,7 +13,7 @@ object AsyncWindup {
         require(!abstractWindup.cancelled.get()) { "Tried to schedule a windupData that has already been cancelled." }
 
         // Request is a valid request.
-        addWindupData(abstractWindup) // Add it to the tracked windupData.
+        WindupWatcher.addWindupData(abstractWindup) // Add it to the tracked windupData.
 
         scope.launch {
             var countingDown = true
@@ -32,7 +32,7 @@ object AsyncWindup {
         if (abstractWindup.windupDelay.get() > 0) {
             // Countdown not finished
             if (abstractWindup.cancelled.get()) {
-                removeWindupData(abstractWindup)
+                WindupWatcher.removeWindupData(abstractWindup)
                 return false
             }
 
@@ -44,14 +44,14 @@ object AsyncWindup {
         }
 
         if (abstractWindup.cancelled.get()) {
-            removeWindupData(abstractWindup)
+            WindupWatcher.removeWindupData(abstractWindup)
             return false
         }
 
         // Delay is zero, countdown finished
         onCountdownFinished(abstractWindup)
 
-        removeWindupData(abstractWindup)
+        WindupWatcher.removeWindupData(abstractWindup)
         return false
     }
 

--- a/common/src/main/java/net/superricky/tpaplusplus/windupcooldown/windup/WindupWatcher.kt
+++ b/common/src/main/java/net/superricky/tpaplusplus/windupcooldown/windup/WindupWatcher.kt
@@ -7,65 +7,67 @@ import net.superricky.tpaplusplus.config.Messages
 import net.superricky.tpaplusplus.util.MsgFmt
 import java.util.concurrent.ConcurrentHashMap
 
-private val dispatcher: CoroutineDispatcher = Dispatchers.IO
-private val scope: CoroutineScope = CoroutineScope(dispatcher)
+object WindupWatcher {
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+    private val scope: CoroutineScope = CoroutineScope(dispatcher)
 
-private val trackedAbstractWindupData: MutableSet<AbstractWindup> = ConcurrentHashMap.newKeySet()
+    private val trackedAbstractWindupData: MutableSet<AbstractWindup> = ConcurrentHashMap.newKeySet()
 
-private const val WINDUP_DISABLED_DISTANCE = -1.0
-private var ticking = true
+    private const val WINDUP_DISABLED_DISTANCE = -1.0
+    private var ticking = true
 
-fun clearTrackedWindupData() {
-    trackedAbstractWindupData.clear()
-}
+    fun clearTrackedWindupData() {
+        trackedAbstractWindupData.clear()
+    }
 
-fun removeWindupData(abstractWindup: AbstractWindup) {
-    trackedAbstractWindupData.remove(abstractWindup)
-}
+    fun removeWindupData(abstractWindup: AbstractWindup) {
+        trackedAbstractWindupData.remove(abstractWindup)
+    }
 
-fun addWindupData(abstractWindup: AbstractWindup) {
-    trackedAbstractWindupData.add(abstractWindup)
-}
+    fun addWindupData(abstractWindup: AbstractWindup) {
+        trackedAbstractWindupData.add(abstractWindup)
+    }
 
-fun startAsyncTickLoop(tickRate: Long) {
-    scope.launch {
-        while (ticking) {
-            runTick()
-            delay(1000L / tickRate) // We divide 1000 by the tickRate to simultaneously get the inverse of the tickRate (get the amount of time to delay for) and to convert it to milliseconds.
+    fun startAsyncTickLoop(tickRate: Long) {
+        scope.launch {
+            while (ticking) {
+                runTick()
+                delay(1000L / tickRate) // We divide 1000 by the tickRate to simultaneously get the inverse of the tickRate (get the amount of time to delay for) and to convert it to milliseconds.
+            }
         }
     }
-}
 
-fun runTick() {
-    for (windupData in trackedAbstractWindupData) {
-        val windupDistance = windupData.windupDistance
+    fun runTick() {
+        for (windupData in trackedAbstractWindupData) {
+            val windupDistance = windupData.windupDistance
 
-        if (windupDistance == WINDUP_DISABLED_DISTANCE) continue
+            if (windupDistance == WINDUP_DISABLED_DISTANCE) continue
 
-        if (windupData.cancelled.get()) continue
+            if (windupData.cancelled.get()) continue
 
-        if (TPAPlusPlus.distance3D(
-                windupData.acceptX,
-                windupData.acceptY,
-                windupData.acceptZ,
-                windupData.windupPlayer.x,
-                windupData.windupPlayer.y,
-                windupData.windupPlayer.z
-            ) > windupDistance
-        ) {
-            // Squared distance between the position which they started the countdown, and their current position is larger than the allowed distance set in the Config.
-            windupData.cancelled.set(true)
+            if (TPAPlusPlus.distance3D(
+                    windupData.acceptX,
+                    windupData.acceptY,
+                    windupData.acceptZ,
+                    windupData.windupPlayer.x,
+                    windupData.windupPlayer.y,
+                    windupData.windupPlayer.z
+                ) > windupDistance
+            ) {
+                // Squared distance between the position which they started the countdown, and their current position is larger than the allowed distance set in the Config.
+                windupData.cancelled.set(true)
 
-            windupData.windupPlayer.sendSystemMessage(
-                Component.literal(
-                    MsgFmt.fmt(
-                        Messages.PLAYER_MOVED_DURING_WINDUP.get(),
-                        mapOf("command_used" to windupData.commandName)
+                windupData.windupPlayer.sendSystemMessage(
+                    Component.literal(
+                        MsgFmt.fmt(
+                            Messages.PLAYER_MOVED_DURING_WINDUP.get(),
+                            mapOf("command_used" to windupData.commandName)
+                        )
                     )
                 )
-            )
 
-            trackedAbstractWindupData.remove(windupData)
+                trackedAbstractWindupData.remove(windupData)
+            }
         }
     }
 }


### PR DESCRIPTION
Refactor WindupWatcher.kt to use object singleton instead of static access. Prevents namespace pollution from top-level functions. The JIT optimises singletons to static access anyway.