### PR TITLE
Refactor TimeoutManager.kt to use object {} singleton instead of stat…

### DIFF
--- a/common/src/main/java/net/superricky/tpaplusplus/TPAPlusPlus.java
+++ b/common/src/main/java/net/superricky/tpaplusplus/TPAPlusPlus.java
@@ -18,7 +18,7 @@ import net.superricky.tpaplusplus.config.Config;
 import net.superricky.tpaplusplus.io.ServerLifecycleHandler;
 import net.superricky.tpaplusplus.network.UpdateCheckKt;
 import net.superricky.tpaplusplus.timeout.RequestTimeoutEvent;
-import net.superricky.tpaplusplus.timeout.TimeoutManagerKt;
+import net.superricky.tpaplusplus.timeout.TimeoutManager;
 import net.superricky.tpaplusplus.util.MsgFmt;
 import net.superricky.tpaplusplus.windupcooldown.windup.WindupWatcher;
 import org.slf4j.Logger;
@@ -62,7 +62,7 @@ public class TPAPlusPlus {
         EntityEvent.LIVING_DEATH.register((deadEntity, source) -> DeathHelper.onDeath(deadEntity));
 
         LOGGER.info("REGISTERING \"RequestTimeoutEvent\"...");
-        RequestTimeoutEvent.EVENT.register(TimeoutManagerKt::onTimeoutEvent);
+        RequestTimeoutEvent.EVENT.register(TimeoutManager.INSTANCE::onTimeoutEvent);
 
         if (Config.USE_NON_BLOCKING_ASYNC_TICK_LOOP.get()) {
             LOGGER.warn("USING EXPERIMENTAL NON BLOCKING TICK LOOP");

--- a/common/src/main/java/net/superricky/tpaplusplus/commands/send/SendTPA.java
+++ b/common/src/main/java/net/superricky/tpaplusplus/commands/send/SendTPA.java
@@ -10,7 +10,7 @@ import net.superricky.tpaplusplus.io.SaveDataManager;
 import net.superricky.tpaplusplus.limitations.LimitationManager;
 import net.superricky.tpaplusplus.requests.Request;
 import net.superricky.tpaplusplus.requests.RequestHelper;
-import net.superricky.tpaplusplus.timeout.TimeoutManagerKt;
+import net.superricky.tpaplusplus.timeout.TimeoutManager;
 import net.superricky.tpaplusplus.util.MsgFmt;
 import net.superricky.tpaplusplus.windupcooldown.cooldown.AsyncCooldownHelper;
 import net.superricky.tpaplusplus.windupcooldown.cooldown.AsyncCooldownKt;
@@ -95,7 +95,7 @@ public class SendTPA {
         RequestHelper.getRequestSet().add(request);
 
         if (!Objects.equals(Config.TPA_TIMEOUT_IN_SECONDS.get(), Config.TPA_TIMEOUT_DISABLED)) {
-            TimeoutManagerKt.scheduleTeleportTimeout(request, Config.TPA_TIMEOUT_IN_SECONDS.get());
+            TimeoutManager.INSTANCE.scheduleTeleportTimeout(request, Config.TPA_TIMEOUT_IN_SECONDS.get());
         }
 
 

--- a/common/src/main/java/net/superricky/tpaplusplus/io/ServerLifecycleHandler.java
+++ b/common/src/main/java/net/superricky/tpaplusplus/io/ServerLifecycleHandler.java
@@ -1,7 +1,7 @@
 package net.superricky.tpaplusplus.io;
 
 import net.superricky.tpaplusplus.config.Config;
-import net.superricky.tpaplusplus.timeout.TimeoutManagerKt;
+import net.superricky.tpaplusplus.timeout.TimeoutManager;
 
 public class ServerLifecycleHandler {
     public static void onServerStart() {
@@ -10,7 +10,7 @@ public class ServerLifecycleHandler {
 
     public static void onServerStop() {
         AutosaveSchedulerKt.shutdownNow();
-        TimeoutManagerKt.shutdownNow();
+        TimeoutManager.INSTANCE.shutdownNow();
 
         SaveDataManager.savePlayerData();
     }

--- a/common/src/main/java/net/superricky/tpaplusplus/timeout/TimeoutManager.kt
+++ b/common/src/main/java/net/superricky/tpaplusplus/timeout/TimeoutManager.kt
@@ -8,29 +8,52 @@ import net.superricky.tpaplusplus.requests.Request
 import net.superricky.tpaplusplus.requests.RequestHelper
 import net.superricky.tpaplusplus.util.MsgFmt
 
-// Create a shared thread pool
-private val dispatcher: CoroutineDispatcher = Dispatchers.IO
-private val scope: CoroutineScope = CoroutineScope(dispatcher)
+object TimeoutManager {
+    // Create a shared thread pool
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO
+    private val scope: CoroutineScope = CoroutineScope(dispatcher)
 
-fun scheduleTeleportTimeout(request: Request, timeoutSeconds: Long) {
-    scope.launch {
-        delay(timeoutSeconds * 1000L)
-        RequestTimeoutEvent.EVENT.invoker().onRequestTimeout(request)
+    fun scheduleTeleportTimeout(request: Request, timeoutSeconds: Long) {
+        scope.launch {
+            delay(timeoutSeconds * 1000L)
+            RequestTimeoutEvent.EVENT.invoker().onRequestTimeout(request)
+        }
     }
-}
 
-fun onTimeoutEvent(request: Request): EventResult {
-    // Check if the request still exists before printing a timeout message
-    if (!RequestHelper.teleportRequestExists(request)) return EventResult.pass()
+    fun onTimeoutEvent(request: Request): EventResult {
+        // Check if the request still exists before printing a timeout message
+        if (!RequestHelper.teleportRequestExists(request)) return EventResult.pass()
 
-    val receiver = request.receiver
-    val sender = request.sender
+        val receiver = request.receiver
+        val sender = request.sender
 
-    if (request.isHereRequest) {
+        if (request.isHereRequest) {
+            sender.sendSystemMessage(
+                Component.literal(
+                    MsgFmt.fmt(
+                        Messages.SENDER_TPAHERE_TIMEOUT.get(),
+                        mapOf("receivers_name" to receiver.displayName.string)
+                    )
+                )
+            )
+
+            receiver.sendSystemMessage(
+                Component.literal(
+                    MsgFmt.fmt(
+                        Messages.RECEIVER_TPAHERE_TIMEOUT.get(),
+                        mapOf("senders_name" to sender.displayName.string)
+                    )
+                )
+            )
+
+            RequestHelper.getRequestSet().remove(request)
+            return EventResult.pass()
+        }
+
         sender.sendSystemMessage(
             Component.literal(
                 MsgFmt.fmt(
-                    Messages.SENDER_TPAHERE_TIMEOUT.get(),
+                    Messages.SENDER_TPA_TIMEOUT.get(),
                     mapOf("receivers_name" to receiver.displayName.string)
                 )
             )
@@ -39,7 +62,7 @@ fun onTimeoutEvent(request: Request): EventResult {
         receiver.sendSystemMessage(
             Component.literal(
                 MsgFmt.fmt(
-                    Messages.RECEIVER_TPAHERE_TIMEOUT.get(),
+                    Messages.RECEIVER_TPA_TIMEOUT.get(),
                     mapOf("senders_name" to sender.displayName.string)
                 )
             )
@@ -49,28 +72,7 @@ fun onTimeoutEvent(request: Request): EventResult {
         return EventResult.pass()
     }
 
-    sender.sendSystemMessage(
-        Component.literal(
-            MsgFmt.fmt(
-                Messages.SENDER_TPA_TIMEOUT.get(),
-                mapOf("receivers_name" to receiver.displayName.string)
-            )
-        )
-    )
-
-    receiver.sendSystemMessage(
-        Component.literal(
-            MsgFmt.fmt(
-                Messages.RECEIVER_TPA_TIMEOUT.get(),
-                mapOf("senders_name" to sender.displayName.string)
-            )
-        )
-    )
-
-    RequestHelper.getRequestSet().remove(request)
-    return EventResult.pass()
-}
-
-fun shutdownNow() {
-    scope.cancel()
+    fun shutdownNow() {
+        scope.cancel()
+    }
 }


### PR DESCRIPTION
Refactor TimeoutManager.kt to use object singleton instead of static access. Prevents namespace pollution from top-level functions. The JIT optimises singletons to static access anyway.