### PR TITLE
Make forgix use the Merged directory instead of ./build/forgix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
 // We use Forgix (https://github.com/PacifistMC/Forgix) for creating "universal" jars that can be run on any modloader (that the code supports)
 // No more downloading the wrong jar!
 forgix {
-    destinationDirectory = layout.projectDirectory.dir("build/forgix")
+    destinationDirectory = layout.projectDirectory.dir("Merged")
     archiveClassifier = "universal"
     archiveVersion = rootProject.mod_version
 }


### PR DESCRIPTION
This is how TPA++ worked before. I consider the previous behavior a regression, since there wasn't any principled reason for it to change from how it worked before.