### PR TITLE
Add "ADR-002: Add GitHub Actions"

### DIFF
--- a/docs/adr/002-add-github-actions.md
+++ b/docs/adr/002-add-github-actions.md
@@ -1,0 +1,28 @@
+# 002: Add GitHub actions
+
+**Status:** Accepted\
+**Date:** 26-12-2025
+
+## Context
+TPA++ has unit tests, but they're not run on commits??
+TPA++ lacks a standardized workflow for uploading to Modrinth/CurseForge
+TPA++ lacks a standardized workflow for providing bleeding edge builds to the community.
+Beta/Alpha builds clutter up CurseForge/Modrinth and confuse users.
+
+## Decision
+Add GitHub actions. Configure GitHub actions to run unit tests and comment the results. Configure GitHub actions to publish artifacts on commits that successfuly compile&test. 
+
+GitHub actions enables Modrinth/CurseForge uploading, but that can come at a later date.
+
+## Options Considered
+**Do nothing**: Because these pain points have been the things really putting me off from maintaining TPA++
+**Use an external system like Jenkins**: GitHub actions is just right there. The only benefit I see to an external project is no account requirement for downloading artifacts, but that can be solved with a service such as [nightly.link](https://nightly.link). For my first project with proper CI/CD, learning an external tool doesn't have proper ROI.
+
+## Consequences
+**Positive:**
+* Faster iteration, no more going through the whole manual upload process for bleeding edge builds.
+* Lots of room to grow (for example automatic Modrinth/CurseForge uploading)
+
+**Negative:**
+* Deeper into the GitHub ecosystem, makes it harder to pivot to Gitlab Gitea or other alternatives if ever necessary
+* Requires an account to download artifacts. As seen above, I plan on mitigating this with [nightly.link](https://nightly.link).

--- a/docs/adr/002-add-github-actions.md
+++ b/docs/adr/002-add-github-actions.md
@@ -1,27 +1,28 @@
 # 002: Add GitHub actions
 
 **Status:** Accepted\
-**Date:** 26-12-2025
+**Date:** 1-1-2026
 
 ## Context
-TPA++ has unit tests, but they're not run on commits??
-TPA++ lacks a standardized workflow for uploading to Modrinth/CurseForge
-TPA++ lacks a standardized workflow for providing bleeding edge builds to the community.
+The unit tests are currently undocumented and manual—a bad combo that ensures nobody runs them.\
+TPA++ lacks a standardized workflow for uploading to Modrinth/CurseForge\
+TPA++ lacks a standardized workflow for providing bleeding edge builds to the community.\
 Beta/Alpha builds clutter up CurseForge/Modrinth and confuse users.
 
 ## Decision
-Add GitHub actions. Configure GitHub actions to run unit tests and comment the results. Configure GitHub actions to publish artifacts on commits that successfuly compile&test. 
-
-GitHub actions enables Modrinth/CurseForge uploading, but that can come at a later date.
+Add GitHub actions.\
+Configure GitHub actions to run unit tests and comment the results.\
+Configure GitHub actions to publish artifacts on commits that successfuly compile&test.\
+We will **not** be implementing Modrinth/CurseForge uploading in this iteration to keep things simple.
 
 ## Options Considered
-**Do nothing**: Because these pain points have been the things really putting me off from maintaining TPA++
+**Do nothing**: Because these pain points have been the things really putting me off from maintaining TPA++\
 **Use an external system like Jenkins**: GitHub actions is just right there. The only benefit I see to an external project is no account requirement for downloading artifacts, but that can be solved with a service such as [nightly.link](https://nightly.link). For my first project with proper CI/CD, learning an external tool doesn't have proper ROI.
 
 ## Consequences
 **Positive:**
 * Faster iteration, no more going through the whole manual upload process for bleeding edge builds.
-* Lots of room to grow (for example automatic Modrinth/CurseForge uploading)
+* Lots of room to grow (for example, GitHub actions is great at automatic Modrinth/CurseForge uploading)
 
 **Negative:**
 * Deeper into the GitHub ecosystem, makes it harder to pivot to Gitlab Gitea or other alternatives if ever necessary

--- a/docs/adr/002-add-github-actions.md
+++ b/docs/adr/002-add-github-actions.md
@@ -12,11 +12,12 @@ Beta/Alpha builds clutter up CurseForge/Modrinth and confuse users.
 ## Decision
 Add GitHub actions.\
 Configure GitHub actions to run unit tests and comment the results.\
-Configure GitHub actions to publish artifacts on commits that successfuly compile&test.\
+Configure GitHub actions to publish artifacts on commits to main that successfuly compile&test.\
 We will **not** be implementing Modrinth/CurseForge uploading in this iteration to keep things simple.
 
 ## Options Considered
 **Do nothing**: Because these pain points have been the things really putting me off from maintaining TPA++\
+**Produce artifacts on other branches**: Not sure how that would play with tools like [nightly.link](https://nightly.link). If it did end up playing nicely, I pretty much want artifacts to be bleeding edge builds for the community. So, don't want them to be confused downloading a broken build from a PR that's in-progress for example.
 **Use an external system like Jenkins**: GitHub actions is just right there. The only benefit I see to an external project is no account requirement for downloading artifacts, but that can be solved with a service such as [nightly.link](https://nightly.link). For my first project with proper CI/CD, learning an external tool doesn't have proper ROI.
 
 ## Consequences

--- a/docs/adr/002-add-github-actions.md
+++ b/docs/adr/002-add-github-actions.md
@@ -17,7 +17,7 @@ We will **not** be implementing Modrinth/CurseForge uploading in this iteration 
 
 ## Options Considered
 **Do nothing**: Because these pain points have been the things really putting me off from maintaining TPA++\
-**Produce artifacts on other branches**: Not sure how that would play with tools like [nightly.link](https://nightly.link). If it did end up playing nicely, I pretty much want artifacts to be bleeding edge builds for the community. So, don't want them to be confused downloading a broken build from a PR that's in-progress for example.
+**Produce artifacts on other branches**: Not sure how that would play with tools like [nightly.link](https://nightly.link). If it did end up playing nicely, I pretty much want artifacts to be bleeding edge builds for the community. So, don't want them to be confused downloading a broken build from a PR that's in-progress for example.\
 **Use an external system like Jenkins**: GitHub actions is just right there. The only benefit I see to an external project is no account requirement for downloading artifacts, but that can be solved with a service such as [nightly.link](https://nightly.link). For my first project with proper CI/CD, learning an external tool doesn't have proper ROI.
 
 ## Consequences


### PR DESCRIPTION
Cherry picked commits from #25 containing ADR since they were meant to go in a separate commit.

This provides the missing ADR for adding GitHub actions. Since I forgot to add it in #23, this ADR contains the decision made in both #23 and #25.